### PR TITLE
Solid expects OAuth token's 'aud' claim to include 'sub'.

### DIFF
--- a/src/AccessToken.js
+++ b/src/AccessToken.js
@@ -77,6 +77,14 @@ class AccessToken extends JWT {
     let key = keys.token.signing[alg].privateKey
     let kid = keys.token.signing[alg].publicJwk.kid
 
+    if (!Array.isArray(aud)) {
+      aud = [ aud ]
+    }
+
+    if (!aud.includes(sub)) {
+      aud.push(sub)
+    }
+
     let header = { alg, kid }
     let payload = { iss, aud, sub, exp, iat, jti, scope }
 

--- a/test/AccessTokenSpec.js
+++ b/test/AccessTokenSpec.js
@@ -143,7 +143,9 @@ describe('AccessToken', () => {
       let token = AccessToken.issue(provider, options)
 
       expect(token.payload.iss).to.equal(provider.issuer)
-      expect(token.payload.aud).to.equal('client123')
+      expect(Array.isArray(token.payload.aud)).to.be.true
+      expect(token.payload.aud.includes('client123')).to.be.true
+      expect(token.payload.aud.includes(token.payload.sub)).to.be.true
       expect(token.payload.sub).to.equal('user123')
       expect(token.payload.scope).to.equal('openid profile')
     })


### PR DESCRIPTION
Relates to: <https://github.com/solid/node-solid-server/issues/1061>