### PR TITLE
Defect OpenId configuration issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v0.9.0
+- Fix to mask properties that should not be part of the OIDC configuration.
+
 ## v0.6.0 - 2019-11-08
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@solid/oidc-op",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solid/oidc-op",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "engines": {
     "node": ">=10.0"
   },

--- a/src/Provider.js
+++ b/src/Provider.js
@@ -211,7 +211,7 @@ class Provider {
    * openidConfiguration
    */
   get openidConfiguration () {
-    return JSON.stringify(this)
+    return JSON.stringify(this, (key, value) => key !== "keys" ? value : undefined)
   }
 
   /**

--- a/test/handlers/OpenIDConfigurationRequestSpec.js
+++ b/test/handlers/OpenIDConfigurationRequestSpec.js
@@ -31,6 +31,7 @@ describe('OpenIDConfigurationRequest', () => {
     res = HttpMocks.createResponse()
 
     provider = new Provider({ issuer: providerUri })
+    provider.initializeKeyChain();
   })
 
   it('should respond with the provider configuration in JSON format', () => {
@@ -41,5 +42,15 @@ describe('OpenIDConfigurationRequest', () => {
     let config = JSON.parse(res._getData())
 
     expect(config['authorization_endpoint']).to.equal('https://example.com/authorize')
+  })
+
+  it('should mask properties that are not part of OIDC', () => {
+    OpenIDConfigurationRequest.handle(req, res, provider)
+
+    expect(res._isJSON()).to.be.true()
+
+    let config = JSON.parse(res._getData())
+
+    expect(config['keys']).to.be.undefined()
   })
 })


### PR DESCRIPTION
The `keys` property is getting returned and should be masked from the oidc configuration response.