### PR TITLE
Return an ID token on refresh

### DIFF
--- a/src/handlers/TokenRequest.js
+++ b/src/handlers/TokenRequest.js
@@ -503,6 +503,7 @@ class TokenRequest extends BaseRequest {
     return Promise.resolve({})
       .then(() => this.verifyRefreshToken(request))
       .then(response => request.includeAccessToken(response))
+      .then(response => request.includeIDToken(response))
       .then(response => {
         request.res.json(response)
       })


### PR DESCRIPTION
This intends to fix #31.

As part of the refresh grant, the ID token is now sent along with the access token.

Note that not being familiar with the test setup, and pre-existing tests not being present for the refresh grant, I did not add test coverage. More generally, I couldn't test on a local deployment, because `@inrupt/generate-oidc-token`, which makes it possible to get a refresh token easily and test if this PR fixes the behaviour, prevents using self-signed certificates. Would it be possible to deploy this on `https://solidcommunity.net:8443`, as was deployed the previous staged change, to facilitate tests ?