### PR TITLE
scopes-claims-supported

### DIFF
--- a/src/Provider.js
+++ b/src/Provider.js
@@ -35,8 +35,7 @@ const DEFAULT_GRANT_TYPES_SUPPORTED = [
 ]
 const DEFAULT_SCOPES_SUPPORTED = [
   'openid',
-  'offline_access',
-  'webid'
+  'offline_access'
 ]
 const DEFAULT_SUBJECT_TYPES_SUPPORTED = ['public']
 
@@ -58,7 +57,8 @@ class Provider {
 
     this.issuer = data.issuer
     this.jwks_uri = data.jwks_uri
-    this.scopes_supported = data.scopes_supported
+    this.scopes_supported = data.scopes_supported ||
+      DEFAULT_SCOPES_SUPPORTED
     this.response_types_supported = data.response_types_supported ||
       DEFAULT_RESPONSE_TYPES_SUPPORTED
     this.token_types_supported = data.token_types_supported ||
@@ -67,8 +67,6 @@ class Provider {
       DEFAULT_RESPONSE_MODES_SUPPORTED
     this.grant_types_supported = data.grant_types_supported ||
       DEFAULT_GRANT_TYPES_SUPPORTED
-    this.scopes_supported = data.scopes_supported ||
-      DEFAULT_SCOPES_SUPPORTED
     this.subject_types_supported = data.subject_types_supported ||
       DEFAULT_SUBJECT_TYPES_SUPPORTED
     this.id_token_signing_alg_values_supported =
@@ -95,7 +93,6 @@ class Provider {
       data.token_endpoint_auth_signing_alg_values_supported || ['RS256']
     this.display_values_supported = data.display_values_supported || []
     this.claim_types_supported = data.claim_types_supported || ['normal']
-    this.claims_supported = data.claims_supported || ['webid']
     this.service_documentation = data.service_documentation
     this.claims_locales_supported = data.claims_locales_supported
     this.ui_locales_supported = data.ui_locales_supported

--- a/src/Provider.js
+++ b/src/Provider.js
@@ -33,6 +33,11 @@ const DEFAULT_GRANT_TYPES_SUPPORTED = [
   'refresh_token',
   'client_credentials'
 ]
+const DEFAULT_SCOPES_SUPPORTED = [
+  'openid',
+  'offline_access',
+  'webid'
+]
 const DEFAULT_SUBJECT_TYPES_SUPPORTED = ['public']
 
 const DEFAULT_TOKEN_TYPES_SUPPORTED = ['legacyPop', 'dpop']
@@ -62,6 +67,8 @@ class Provider {
       DEFAULT_RESPONSE_MODES_SUPPORTED
     this.grant_types_supported = data.grant_types_supported ||
       DEFAULT_GRANT_TYPES_SUPPORTED
+    this.scopes_supported = data.scopes_supported ||
+      DEFAULT_SCOPES_SUPPORTED
     this.subject_types_supported = data.subject_types_supported ||
       DEFAULT_SUBJECT_TYPES_SUPPORTED
     this.id_token_signing_alg_values_supported =
@@ -88,7 +95,7 @@ class Provider {
       data.token_endpoint_auth_signing_alg_values_supported || ['RS256']
     this.display_values_supported = data.display_values_supported || []
     this.claim_types_supported = data.claim_types_supported || ['normal']
-    this.claims_supported = data.claims_supported || []
+    this.claims_supported = data.claims_supported || ['webid']
     this.service_documentation = data.service_documentation
     this.claims_locales_supported = data.claims_locales_supported
     this.ui_locales_supported = data.ui_locales_supported

--- a/test/config/provider.json
+++ b/test/config/provider.json
@@ -24,6 +24,11 @@
     "refresh_token",
     "client_credentials"
   ],
+  "scopes_supported": [
+    "openid",
+    "offline_access",
+    "webid"
+  ],
   "subject_types_supported": [
     "public"
   ],
@@ -43,7 +48,7 @@
   "claim_types_supported": [
     "normal"
   ],
-  "claims_supported": "",
+  "claims_supported": "webid",
   "claims_parameter_supported": false,
   "request_parameter_supported": false,
   "request_uri_parameter_supported": true,


### PR DESCRIPTION
add "webid" as scopes_supported and claims supported to follow solid-oidc spec
and "openid" and "ofline_access" as scopes_supported as requested by @inrupt/solid-client-authn@1.11.5